### PR TITLE
Add the Keep Android Open countdown banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -299,6 +299,7 @@
     </div>
   </footer>
   <script type="module" src="/src/main.ts"></script>
+  <script src="https://keepandroidopen.org/banner.js?size=mini"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Added the banner from keepandroidopen.org with a countdown until Android becomes a locked-down platform.
Go to https://keepandroidopen.org/banner for more information.